### PR TITLE
Update insights-custom-repos.yml

### DIFF
--- a/docs/quickstarts/insights-custom-repos/insights-custom-repos.yml
+++ b/docs/quickstarts/insights-custom-repos/insights-custom-repos.yml
@@ -25,12 +25,16 @@ spec:
 
     In this quick start, you will add a custom repository to the Red Hat Hybrid Cloud Console and create an image with custom content.
 
+    Note: This procedure is available just for the **Preview** experience.  
+
   tasks:
     - title: Add a custom repository
       description: |-
         
         <h4 id="ib-add-custom"><b>Add a Custom Repository:</b></h4>
 
+        1. Toggle the **Preview** button to on in the top right corner.
+       
         1. Click the Settings <i class="fas fa-cog"></i> icon in the top right corner.
 
         1. In Settings, click **Repositories** in the left menu.


### PR DESCRIPTION
I suggest adding this note because the "Build an image with custom content" quick start Insights Learning Resources page (https://console.redhat.com/insights/learning-resources) is valid only in the Preview mode. The first procedure "Add a Custom Repository" in the  Quick start doesn't work today unless preview mode is enabled. This is a temporary situation. When the HMS feature is GA, this will work as documented. Because the quick start framework doesn't provide a way to show a Quick Start card only for the preview mode, I suggest also adding a step that tells the user to enable preview mode before proceeding with the rest of the quick start procedures. 

I have set a note to remember to remove the preview step when the features described in the Quick Start are GA.